### PR TITLE
Remove legacy npm registry

### DIFF
--- a/lib/create-react-storefront-internal.js
+++ b/lib/create-react-storefront-internal.js
@@ -66,7 +66,7 @@ const createReactStorefrontInternal = async (options, userConfig) => {
 
   try {
     spinner = ora('Installing dependencies...').start()
-    await exec('npm install --registry=https://npm-proxy.fury.io/moovweb/ --legacy-peer-deps', { cwd: targetPath })
+    await exec('npm install --legacy-peer-deps', { cwd: targetPath })
     spinner.succeed('Installing dependencies... done.')
   } catch (e) {
     spinner.fail('npm install failed')


### PR DESCRIPTION
This registry is not actively published to and installing the latest dependencies fails because `react-storefront-amp@1.2.10` is on NPM and not Gemfury.